### PR TITLE
Fixing crash when x, y, width or height isn't set on <rects>

### DIFF
--- a/SVGPathSerializing.mm
+++ b/SVGPathSerializing.mm
@@ -150,10 +150,10 @@ CGPathRef svgParser::readRectTag()
                      * const widthDef  = (char *)xmlTextReaderGetAttribute(_xmlReader, (xmlChar*)"width"),
                      * const heightDef = (char *)xmlTextReaderGetAttribute(_xmlReader, (xmlChar*)"height");
 
-	CGFloat const xPos = (xDef != NULL) ? atof(xDef) : 0.0f;
-	CGFloat const yPos = (yDef != NULL) ? atof(yDef) : 0.0f;
-	CGFloat const width = (widthDef != NULL) ? atof(widthDef) : 0.0f;
-	CGFloat const height = (heightDef != NULL) ? atof(heightDef) : 0.0f;
+    CGFloat const xPos = (xDef != NULL) ? atof(xDef) : 0.0f;
+    CGFloat const yPos = (yDef != NULL) ? atof(yDef) : 0.0f;
+    CGFloat const width = (widthDef != NULL) ? atof(widthDef) : 0.0f;
+    CGFloat const height = (heightDef != NULL) ? atof(heightDef) : 0.0f;
 	
     CGRect const rect = { xPos, yPos, width, height };
     NSString * const pathDefinition = [NSString stringWithFormat:


### PR DESCRIPTION
Defaulting to 0.0f when attributes for any of these are missing.

Ps. Looking forward to seeing the one-liner you'll compress this into ;)
