### PR TITLE
NSNumberFormatter was region bound

### DIFF
--- a/SVGPathSerializing.mm
+++ b/SVGPathSerializing.mm
@@ -612,6 +612,7 @@ static NSString *_SVGFormatNumber(NSNumber * const aNumber)
         fmt = [NSNumberFormatter new];
         fmt.numberStyle = NSNumberFormatterDecimalStyle;
         fmt.maximumSignificantDigits = 3;
+        fmt.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"];
     });
     return [fmt stringFromNumber:aNumber];
 }


### PR DESCRIPTION
NSNumberFormatter was region bound so regions that use , (comma) instead of . (dot) for decimal seperator would get 1,200 instead of 1.200
